### PR TITLE
Support defines for some Vue.config values.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # bedrock-vue ChangeLog
 
+### Added
+- Allow defines for Vue.config.{devtools,productionTip,performance}.
+
 ## 2.0.1 - 2019-11-12
 
 ### Changed

--- a/README.md
+++ b/README.md
@@ -1,2 +1,25 @@
 # bedrock-vue
-Vue frontend framework running on Bedrock
+
+[Vue][] frontend framework running on [Bedrock][].
+
+## Bundling
+
+Special constants are available to setup the [Vue Global Config][] at bundle
+time. If unset, the config values are left at their defaults.
+
+- `VUE_DEVTOOLS`: [Vue.config.devtools](https://vuejs.org/v2/api/#devtools)
+- `VUE_PERFORMANCE`: [Vue.config.performance](https://vuejs.org/v2/api/#performance)
+- `VUE_PRODUCTIONTIP`: [Vue.config.productionTip](https://vuejs.org/v2/api/#productionTip)
+
+When using the [webpack][] [DefinePlugin][], these can be directly set to a
+JSON truthy value. A [Bedrock][] command line option can also be used:
+
+```sh
+node app.js --webpack-define VUE_PERFORMANCE=true
+```
+
+[Bedrock]: https://github.com/digitalbazaar/bedrock
+[DefinePlugin]: https://webpack.js.org/plugins/define-plugin/
+[Vue Global Config]: https://vuejs.org/v2/api/#Global-Config
+[Vue]: https://vuejs.org/
+[webpack]: https://webpack.js.org/

--- a/index.js
+++ b/index.js
@@ -13,18 +13,18 @@ import VueRouter from 'vue-router';
 
 /* global
  *   VUE_DEVTOOLS
- *   VUE_PRODUCTIONTIP
  *   VUE_PERFORMANCE
+ *   VUE_PRODUCTIONTIP
  */
 // early Vue config setup from possible defines
 if(typeof VUE_DEVTOOLS !== 'undefined') {
   Vue.config.devtools = JSON.parse(VUE_DEVTOOLS);
 }
-if(typeof VUE_PRODUCTIONTIP !== 'undefined') {
-  Vue.config.productionTip = JSON.parse(VUE_PRODUCTIONTIP);
-}
 if(typeof VUE_PERFORMANCE !== 'undefined') {
   Vue.config.performance = JSON.parse(VUE_PERFORMANCE);
+}
+if(typeof VUE_PRODUCTIONTIP !== 'undefined') {
+  Vue.config.productionTip = JSON.parse(VUE_PRODUCTIONTIP);
 }
 
 // autostart once bedrock web app is ready

--- a/index.js
+++ b/index.js
@@ -11,6 +11,22 @@ import BrApp from './BrApp.vue';
 import Vue from 'vue';
 import VueRouter from 'vue-router';
 
+/* global
+ *   VUE_DEVTOOLS
+ *   VUE_PRODUCTIONTIP
+ *   VUE_PERFORMANCE
+ */
+// early Vue config setup from possible defines
+if(typeof VUE_DEVTOOLS !== 'undefined') {
+  Vue.config.devtools = JSON.parse(VUE_DEVTOOLS);
+}
+if(typeof VUE_PRODUCTIONTIP !== 'undefined') {
+  Vue.config.productionTip = JSON.parse(VUE_PRODUCTIONTIP);
+}
+if(typeof VUE_PERFORMANCE !== 'undefined') {
+  Vue.config.performance = JSON.parse(VUE_PERFORMANCE);
+}
+
 // autostart once bedrock web app is ready
 ready.then(() => start());
 


### PR DESCRIPTION
- Allows use of bundler "define" feature to set a few special
  `Vue.config` values at bundling time. Currently set very early.