### PR TITLE
Add support for vue-router v5

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,12 @@
 # bedrock-vue ChangeLog
 
+## 5.2.0 - 2026-06-04
+
+### Changed
+- Add support for `vue-router` v5 by widening the `vue-router` peer dependency
+  range to `^4.0.15 || ^5.0.0`. There are no API changes; v5 is a non-breaking
+  release that merges `unplugin-vue-router` into the core package.
+
 ## 5.1.0 - 2024-02-28
 
 ### Changed

--- a/README.md
+++ b/README.md
@@ -127,6 +127,8 @@ need to be defined by the developer as well.
 
 Vue 3.x uses a new router. This router needs to be created via an imported
 function now, instead of installing a Vue plugin and then using a constructor.
+Both `vue-router` v4 and v5 are supported; the example below is unchanged for
+either version.
 
 Previously:
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@bedrock/vue",
-  "version": "5.1.1-0",
+  "version": "5.2.0",
   "type": "module",
   "description": "Vue frontend framework running on Bedrock",
   "license": "Apache-2.0",
@@ -18,7 +18,7 @@
   "peerDependencies": {
     "@bedrock/web": "^3.0.0",
     "vue": "^3.2.36",
-    "vue-router": "^4.0.15"
+    "vue-router": "^4.0.15 || ^5.0.0"
   },
   "repository": {
     "type": "git",


### PR DESCRIPTION
## Summary

Adds support for `vue-router` v5 by widening the peer dependency range. Closes #18.

Per the [v5.0.0 release notes](https://github.com/vuejs/router/releases/tag/v5.0.0), v5 is a non-breaking release that merges `unplugin-vue-router` into the core package. The only breaking change is the IIFE build dropping bundled `@vue/devtools-api`, which bedrock-vue does not use.

`vue-router` is a peer dependency only — there are no `vue-router` imports in `lib/` or `components/`. The router is created by the consuming app and passed into `augmentRouter({app, router})`, which uses only stable, unchanged APIs (`addRoute`, `currentRoute.value`, `beforeEach`). No source changes are required.

## Changes

- `package.json`: peer dep widened to `^4.0.15 || ^5.0.0`; version bumped `5.1.1-0` → `5.2.0`.
- `CHANGELOG.md`: new `5.2.0` entry.
- `README.md`: note that both v4 and v5 are supported.

Widening (rather than replacing) keeps existing v4 consumers working, so this is a backward-compatible minor release.

## Verification

- `npm install` succeeds with the widened range.
- `npm run lint` passes (the only CI check).
- No automated tests exist in this repo; behavior is unchanged since no source code was modified.

🤖 Generated with [Claude Code](https://claude.com/claude-code)